### PR TITLE
CLDC 1.0 support

### DIFF
--- a/src/tech/alicesworld/ModernConnector/CustomTlsClient.java
+++ b/src/tech/alicesworld/ModernConnector/CustomTlsClient.java
@@ -60,7 +60,7 @@ public class CustomTlsClient extends DefaultTlsClient {
             }
 
             public TlsCredentials getClientCredentials(CertificateRequest certificateRequest) throws IOException {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new IOException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
             }
         };
     }

--- a/src/tech/alicesworld/ModernConnector/ModernConnector.java
+++ b/src/tech/alicesworld/ModernConnector/ModernConnector.java
@@ -97,7 +97,7 @@ public class ModernConnector {
     }
 
     public Object openSocket(String host, int port) {
-        throw new UnsupportedOperationException("Only supported when new upstream is set");
+        throw new RuntimeException("Only supported when new upstream is set");
     }
 
 

--- a/src/tech/alicesworld/ModernConnector/ModernHTTPSConnection.java
+++ b/src/tech/alicesworld/ModernConnector/ModernHTTPSConnection.java
@@ -154,7 +154,7 @@ public final class ModernHTTPSConnection implements HttpsConnection {
     private boolean hasRequestHeaderIgnoreCase(String name) {
         for (int i = 0; i < reqHeaderOrder.size(); i++) {
             String k = (String) reqHeaderOrder.elementAt(i);
-            if (k.equalsIgnoreCase(name)) {
+            if (k.toLowerCase().equals(name.toLowerCase())) {
                 return true;
             }
         }
@@ -400,7 +400,7 @@ public final class ModernHTTPSConnection implements HttpsConnection {
         }
         for (int i = 0; i < respHeaderNames.size(); i++) {
             String n = (String) respHeaderNames.elementAt(i);
-            if (n.equalsIgnoreCase(name)) {
+            if (n.toLowerCase().equals(name.toLowerCase())) {
                 return (String) respHeaderValues.elementAt(i);
             }
         }
@@ -541,15 +541,15 @@ public final class ModernHTTPSConnection implements HttpsConnection {
     }
 
     public long getDate() throws IOException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public long getExpiration() throws IOException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public long getLastModified() throws IOException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     // ------------------------------------------------------------------------

--- a/src/tech/alicesworld/ModernConnector/ModernSecureConnection.java
+++ b/src/tech/alicesworld/ModernConnector/ModernSecureConnection.java
@@ -41,7 +41,7 @@ public class ModernSecureConnection implements SecureConnection {
     }
     
     public SecurityInfo getSecurityInfo() throws IOException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public int getLocalPort() throws IOException {

--- a/src/tech/alicesworld/ModernConnector/WebSocketClient.java
+++ b/src/tech/alicesworld/ModernConnector/WebSocketClient.java
@@ -172,7 +172,7 @@ public class WebSocketClient {
         byte[] maskingKey = new byte[4];
         Random random = new Random();
         for (int i = 0; i < maskingKey.length; i++) {
-            maskingKey[i] = (byte) (random.nextInt(256)); // Generate random byte
+            maskingKey[i] = (byte) (random.nextInt() & 255); // Generate random byte
         }
         frame.write(maskingKey);
 

--- a/src/tech/alicesworld/ModernConnector/WebSocketConnection.java
+++ b/src/tech/alicesworld/ModernConnector/WebSocketConnection.java
@@ -65,19 +65,19 @@ public class WebSocketConnection implements SocketConnection {
     }
 
     public DataInputStream openDataInputStream() throws IOException {
-        throw new UnsupportedOperationException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public InputStream openInputStream() throws IOException {
-        throw new UnsupportedOperationException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public DataOutputStream openDataOutputStream() throws IOException {
-        throw new UnsupportedOperationException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public OutputStream openOutputStream() throws IOException {
-        throw new UnsupportedOperationException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
+        throw new RuntimeException("WebSocket's aren't really streams."); //To change body of generated methods, choose Tools | Templates.
     }
     
     public void sendMessage(String data) throws IOException {


### PR DESCRIPTION
Replaced usage of certain classes/methods with equivalents that are available in CLDC 1.0. 

~~Library (everything except Midlet which I didn't look at)~~ Everything compiles successfully with my app with CLDC 1.0 JAR in bootclasspath.

There probably aren't many CLDC 1.0 phones powerful enough to run this, and I haven't tested this on one, but I figured it was worth doing anyway, since my app targets CLDC 1.0. 